### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/TagsEditText/src/main/java/mabbas007/tagsedittext/utils/ResourceUtils.java
+++ b/TagsEditText/src/main/java/mabbas007/tagsedittext/utils/ResourceUtils.java
@@ -10,7 +10,11 @@ import android.support.annotation.DrawableRes;
 /**
  * Created by Mohammad Abbas on 5/10/2016.
  */
-public class ResourceUtils {
+public final class ResourceUtils {
+
+    private ResourceUtils() throws InstantiationException {
+        throw new InstantiationException("This utility class is created for instantiation");
+    }
 
     public static int getColor(Context context, @ColorRes int resourceId) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
