### PR TITLE
Crash fix on Save/Restore state

### DIFF
--- a/TagsEditText/src/main/java/mabbas007/tagsedittext/TagsEditText.java
+++ b/TagsEditText/src/main/java/mabbas007/tagsedittext/TagsEditText.java
@@ -274,9 +274,10 @@ public class TagsEditText extends AutoCompleteTextView {
             mIsSpacesAllowedInTags = bundle.getBoolean(ALLOW_SPACES_IN_TAGS, mIsSpacesAllowedInTags);
 
             mLastString = bundle.getString(LAST_STRING);
-            Tag[] tags = (Tag[]) bundle.getParcelableArray(TAGS);
-
-            if (tags != null) {
+            Parcelable[] tagsParcelables = bundle.getParcelableArray(TAGS);
+            if (tagsParcelables != null) {
+                Tag[] tags = new Tag[tagsParcelables.length];
+                System.arraycopy(tagsParcelables, 0, tags, 0, tagsParcelables.length);
                 Collections.addAll(mTags, tags);
                 buildStringWithTags(mTags);
                 mTextWatcher.afterTextChanged(getText());

--- a/TagsEditText/src/main/java/mabbas007/tagsedittext/TagsEditText.java
+++ b/TagsEditText/src/main/java/mabbas007/tagsedittext/TagsEditText.java
@@ -278,6 +278,7 @@ public class TagsEditText extends AutoCompleteTextView {
             if (tagsParcelables != null) {
                 Tag[] tags = new Tag[tagsParcelables.length];
                 System.arraycopy(tagsParcelables, 0, tags, 0, tagsParcelables.length);
+                mTags = new ArrayList<>();
                 Collections.addAll(mTags, tags);
                 buildStringWithTags(mTags);
                 mTextWatcher.afterTextChanged(getText());


### PR DESCRIPTION
Hi, thanks for the library!
This PR solves crash that happens every time TagsEditText is saved/restored:

> Process: mabbas007.myapplication, PID: 5755
> java.lang.RuntimeException: Unable to start activity ComponentInfo{mabbas007.myapplication/mabbas007.myapplication.MainActivity}: java.lang.ClassCastException: android.os.Parcelable[] cannot be cast to mabbas007.tagsedittext.TagsEditText$Tag[]
>     at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2426)
>     at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2490)
>     at android.app.ActivityThread.-wrap11(ActivityThread.java)
>     at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1354)
>     at android.os.Handler.dispatchMessage(Handler.java:102)
>     at android.os.Looper.loop(Looper.java:148)
>     at android.app.ActivityThread.main(ActivityThread.java:5443)
>     at java.lang.reflect.Method.invoke(Native Method)
>     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:728)
>     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:618)
>  Caused by: java.lang.ClassCastException: android.os.Parcelable[] cannot be cast to mabbas007.tagsedittext.TagsEditText$Tag[]
>     at mabbas007.tagsedittext.TagsEditText.onRestoreInstanceState(TagsEditText.java:253)
>     at android.view.View.dispatchRestoreInstanceState(View.java:14762)
>     at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3129)
>     at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3129)
>     at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3129)
>     at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3129)
>     at android.view.View.restoreHierarchyState(View.java:14740)
>     at com.android.internal.policy.PhoneWindow.restoreHierarchyState(PhoneWindow.java:2035)
>     at android.app.Activity.onRestoreInstanceState(Activity.java:1008)
>     at android.app.Activity.performRestoreInstanceState(Activity.java:963)
>     at android.app.Instrumentation.callActivityOnRestoreInstanceState(Instrumentation.java:1186)
>     at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2399)
>     at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2490) 
>     at android.app.ActivityThread.-wrap11(ActivityThread.java) 
>     at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1354) 
>     at android.os.Handler.dispatchMessage(Handler.java:102) 
>     at android.os.Looper.loop(Looper.java:148) 
>     at android.app.ActivityThread.main(ActivityThread.java:5443) 
>     at java.lang.reflect.Method.invoke(Native Method) 
>     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:728) 
>     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:618) 
