### PR TITLE
[Proposal] Support tag's padding

### DIFF
--- a/TagsEditText/src/main/java/mabbas007/tagsedittext/TagsEditText.java
+++ b/TagsEditText/src/main/java/mabbas007/tagsedittext/TagsEditText.java
@@ -65,6 +65,10 @@ public class TagsEditText extends AutoCompleteTextView {
     private static final String LEFT_DRAWABLE_RESOURCE = "leftDrawable";
     private static final String RIGHT_DRAWABLE_RESOURCE = "rightDrawable";
     private static final String DRAWABLE_PADDING = "drawablePadding";
+    private static final String TAGS_PADDING_LEFT = "tagsPaddingLeft";
+    private static final String TAGS_PADDING_RIGHT = "tagsPaddingRight";
+    private static final String TAGS_PADDING_TOP = "tagsPaddingTop";
+    private static final String TAGS_PADDING_BOTTOM = "tagsPaddingBottom";
 
     private String mLastString = "";
     private boolean mIsAfterTextWatcherEnabled = true;
@@ -80,6 +84,11 @@ public class TagsEditText extends AutoCompleteTextView {
     private int mRightDrawableResouce = 0;
 
     private int mDrawablePadding;
+
+    private int mTagsPaddingLeft;
+    private int mTagsPaddingRight;
+    private int mTagsPaddingTop;
+    private int mTagsPaddingBottom;
 
     private boolean mIsSpacesAllowedInTags = false;
     private boolean mIsSetTextDisabled = false;
@@ -370,6 +379,10 @@ public class TagsEditText extends AutoCompleteTextView {
             mTagsBackground = ContextCompat.getDrawable(context, R.drawable.oval);
             mRightDrawable = ContextCompat.getDrawable(context, R.drawable.tag_close);
             mDrawablePadding = ResourceUtils.getDimensionPixelSize(context, R.dimen.defaultTagsCloseImagePadding);
+            mTagsPaddingRight = ResourceUtils.getDimensionPixelSize(context, R.dimen.defaultTagsPadding);
+            mTagsPaddingLeft = ResourceUtils.getDimensionPixelSize(context, R.dimen.defaultTagsPadding);
+            mTagsPaddingTop = ResourceUtils.getDimensionPixelSize(context, R.dimen.defaultTagsPadding);
+            mTagsPaddingBottom = ResourceUtils.getDimensionPixelSize(context, R.dimen.defaultTagsPadding);
         } else {
             TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.TagsEditText, defStyleAttr, defStyleRes);
             try {
@@ -383,6 +396,14 @@ public class TagsEditText extends AutoCompleteTextView {
                 mLeftDrawable = typedArray.getDrawable(R.styleable.TagsEditText_tagsCloseImageLeft);
                 mDrawablePadding = typedArray.getDimensionPixelOffset(R.styleable.TagsEditText_tagsCloseImagePadding,
                         ResourceUtils.getDimensionPixelSize(context, R.dimen.defaultTagsCloseImagePadding));
+                mTagsPaddingRight = typedArray.getDimensionPixelSize(R.styleable.TagsEditText_tagsPaddingRight,
+                        ResourceUtils.getDimensionPixelSize(context, R.dimen.defaultTagsPadding));
+                mTagsPaddingLeft = typedArray.getDimensionPixelSize(R.styleable.TagsEditText_tagsPaddingLeft,
+                        ResourceUtils.getDimensionPixelSize(context, R.dimen.defaultTagsPadding));
+                mTagsPaddingTop = typedArray.getDimensionPixelSize(R.styleable.TagsEditText_tagsPaddingTop,
+                        ResourceUtils.getDimensionPixelSize(context, R.dimen.defaultTagsPadding));
+                mTagsPaddingBottom = typedArray.getDimensionPixelSize(R.styleable.TagsEditText_tagsPaddingBottom,
+                        ResourceUtils.getDimensionPixelSize(context, R.dimen.defaultTagsPadding));
             } finally {
                 typedArray.recycle();
             }
@@ -596,6 +617,7 @@ public class TagsEditText extends AutoCompleteTextView {
         textView.setText(text);
         textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, mTagsTextSize);
         textView.setTextColor(mTagsTextColor);
+        textView.setPadding(mTagsPaddingLeft, mTagsPaddingTop, mTagsPaddingRight, mTagsPaddingBottom);
 
         // check Android version for set background
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {

--- a/TagsEditText/src/main/res/values/attrs.xml
+++ b/TagsEditText/src/main/res/values/attrs.xml
@@ -8,5 +8,9 @@
         <attr name="tagsCloseImageLeft" format="integer"/>
         <attr name="tagsCloseImageRight" format="integer"/>
         <attr name="tagsCloseImagePadding" format="dimension" />
+        <attr name="tagsPaddingLeft" format="dimension"/>
+        <attr name="tagsPaddingRight" format="dimension"/>
+        <attr name="tagsPaddingTop" format="dimension"/>
+        <attr name="tagsPaddingBottom" format="dimension"/>
     </declare-styleable>
 </resources>

--- a/TagsEditText/src/main/res/values/defaults.xml
+++ b/TagsEditText/src/main/res/values/defaults.xml
@@ -3,4 +3,5 @@
     <color name="defaultTagsTextColor">#FFFFFF</color>
     <dimen name="defaultTagsTextSize">16sp</dimen>
     <dimen name="defaultTagsCloseImagePadding">10dp</dimen>
+    <dimen name="defaultTagsPadding">0dp</dimen>
 </resources>


### PR DESCRIPTION
Currently, when I have a background drawable xml 

```xml
<shape xmlns:android="http://schemas.android.com/apk/res/android">
    <corners android:radius="4dp"/>
    <solid android:color="@color/solid"/>
    <stroke android:width="1dp"
         android:color="@color/border"/>
</shape>
```

it produce the following

![before](https://cloud.githubusercontent.com/assets/3675458/20871027/52310ec4-bad4-11e6-9876-bb7141c7d128.png)

This pull request let users add padding to the tag. Like the following.

![after](https://cloud.githubusercontent.com/assets/3675458/20871029/53ab8040-bad4-11e6-8a7e-ab8074ed1cfc.png)

```xml
<mabbas007.tagsedittext.TagsEditText
                android:id="@+id/tags_edit"
                android:layout_width="match_parent"
                android:layout_height="wrap_content"
                android:layout_gravity="center"
                android:enabled="true"
                android:focusable="true"
                android:focusableInTouchMode="true"
                android:gravity="center_vertical"
                android:hint="@string/hint"
                android:includeFontPadding="false"
                android:paddingLeft="8dp"
                android:paddingRight="8dp"
                android:textColorHint="@color/text_hint"
                app:allowSpaceInTag="true"
                app:tagsBackground="@drawable/shape"
                app:tagsCloseImagePadding="5dp"
                app:tagsCloseImageRight="@drawable/delete"
                app:tagsPaddingBottom="6dp"
                app:tagsPaddingLeft="10dp"
                app:tagsPaddingRight="10dp"
                app:tagsPaddingTop="6dp"
                app:tagsTextColor="@color/black"
                app:tagsTextSize="@dimen/defaultTagsTextSize"
                />
```

What do you think?